### PR TITLE
Change the parameter type from int to string in ApiUsers.php function…

### DIFF
--- a/MangoPay/ApiUsers.php
+++ b/MangoPay/ApiUsers.php
@@ -145,7 +145,7 @@ class ApiUsers extends Libraries\ApiBase
     /**
      * Get bank account for user
      * @param string $userId User Id
-     * @param int $bankAccountId Bank account Id
+     * @param string $bankAccountId Bank account Id
      *
      * @return \MangoPay\BankAccount Entity of bank account object
      */


### PR DESCRIPTION
… GetBankAccount

Since Mangopay has changed the format of Ids, bank account ids have also changed. As a result, now the ids are string instead of integers. My change proposes a change in $bankAccountId parameter data type from int to string on Line 148.  The reason from proposing this change is that for me, my project was failing phpsalm and phpstan checks